### PR TITLE
Add Docker container for webgl tests

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -55,4 +55,5 @@ docker build \
     -t "$PROJECT_DIR" \
     -f "$DOCKER_DIR/Dockerfile" \
     --build-arg PROJECT_DIR="$PROJECT_DIR" \
+    --build-arg DOCKER_DIR="$DOCKER_DIR" \
     . 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Parse command line arguments
+usage() {
+    echo "Usage: $0 [-p <project-directory>] [-d <docker-directory>]"
+    echo "  -p, --project-dir    Project directory (default: derived from current directory)"
+    echo "  -d, --docker-dir     Docker configuration directory (default: docker/<project-directory>)"
+    echo "Example: $0 -p webgl-test -d docker/webgl-test"
+    exit 1
+}
+
+# Default values
+PROJECT_DIR=""
+DOCKER_DIR=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--project-dir)
+            PROJECT_DIR="$2"
+            shift 2
+            ;;
+        -d|--docker-dir)
+            DOCKER_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# If project directory is not provided, try to derive it from current directory
+if [ -z "$PROJECT_DIR" ]; then
+    PROJECT_DIR=$(basename "$(pwd)")
+fi
+
+# If docker directory is not provided, use the default path
+if [ -z "$DOCKER_DIR" ]; then
+    DOCKER_DIR="$(dirname "$0")/$PROJECT_DIR"
+fi
+
+# Check if docker directory exists
+if [ ! -d "$DOCKER_DIR" ]; then
+    echo "Error: Docker configuration directory not found: $DOCKER_DIR"
+    exit 1
+fi
+
+# Build the Docker image
+docker build \
+    -t "$PROJECT_DIR" \
+    -f "$DOCKER_DIR/Dockerfile" \
+    --build-arg PROJECT_DIR="$PROJECT_DIR" \
+    . 

--- a/docker/webgl-test/.dockerignore
+++ b/docker/webgl-test/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+*.log 

--- a/docker/webgl-test/Dockerfile
+++ b/docker/webgl-test/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:23.10.0-alpine as builder
+FROM node:23.10.0-alpine AS builder
 
 # Get project directory from build argument
 ARG PROJECT_DIR
@@ -22,14 +22,18 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
+# Get docker directory from build argument
+ARG DOCKER_DIR
+ENV DOCKER_DIR=$DOCKER_DIR
+
 # Copy built assets from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY $DOCKER_DIR/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 80
-EXPOSE 80
+EXPOSE 8080
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"] 

--- a/docker/webgl-test/Dockerfile
+++ b/docker/webgl-test/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM node:23.10.0-alpine as builder
+
+# Get project directory from build argument
+ARG PROJECT_DIR
+ENV PROJECT_DIR=$PROJECT_DIR
+
+WORKDIR /app
+
+# Copy package files
+COPY $PROJECT_DIR/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY $PROJECT_DIR/ .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets from builder
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"] 

--- a/docker/webgl-test/nginx.conf
+++ b/docker/webgl-test/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+} 

--- a/webgl-test/.dockerignore
+++ b/webgl-test/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+*.log 

--- a/webgl-test/Dockerfile
+++ b/webgl-test/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM node:23.10.0-alpine as builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets from builder
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"] 

--- a/webgl-test/README.md
+++ b/webgl-test/README.md
@@ -6,18 +6,20 @@ A simple Three.js demo showing a rotating cube using WebGL. This project uses Ty
 
 - Node.js (v23.10.0 or later)
 - npm (comes with Node.js)
+- Docker (optional, for containerized deployment)
 
 ## Getting Started
 
-1. Check Node version:
-```bash
-node --version
-```
-Ensure your Node version is above `v23.10.0` - if so, skip to **step 3**
+### Local Development
 
-2. Install Node.js using `nvm` or your favourite method:
+1. Install Node.js using nvm:
 ```bash
 nvm install --lts
+```
+
+2. Clone the repository and navigate to the project:
+```bash
+cd webgl-test
 ```
 
 3. Install dependencies:
@@ -31,6 +33,20 @@ npm run dev
 ```
 
 The application will be available at http://localhost:5173
+
+### Docker Deployment
+
+1. Build the Docker image:
+```bash
+npm run docker-build
+```
+
+2. Run the container:
+```bash
+docker run -p 8080:80 webgl-test
+```
+
+The application will be available at http://localhost:8080
 
 ## Project Structure
 
@@ -46,11 +62,14 @@ The application will be available at http://localhost:5173
 - **Vite**: Modern build tool that provides fast development server and optimized production builds
 - **TypeScript**: Adds type safety to JavaScript
 - **Three.js**: 3D graphics library for the web
+- **Docker**: Containerization for consistent deployment
+- **Nginx**: Production-grade web server
 
 ### Development Scripts
 - `npm run dev`: Starts the development server with hot module replacement
 - `npm run build`: Creates a production build
 - `npm run preview`: Previews the production build locally
+- `npm run docker-build`: Builds the Docker image using the shared Docker configuration
 
 ### Dependencies
 - `three`: Core Three.js library for 3D graphics

--- a/webgl-test/nginx.conf
+++ b/webgl-test/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+} 

--- a/webgl-test/package.json
+++ b/webgl-test/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "docker-build": "../docker/build.sh -p webgl-test"
+    "docker-build": "cd .. && ./docker/build.sh -p webgl-test"
   },
   "keywords": [],
   "author": "",
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^20.11.24",
     "typescript": "^5.3.3",
-    "vite": "^5.1.4"
+    "vite": "^6.2.4"
   },
   "dependencies": {
     "@types/three": "^0.161.2",

--- a/webgl-test/package.json
+++ b/webgl-test/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "docker-build": "../docker/build.sh -p webgl-test"
   },
   "keywords": [],
   "author": "",

--- a/webgl-test/webgl-demo.ts
+++ b/webgl-test/webgl-demo.ts
@@ -22,7 +22,7 @@ document.body.appendChild( renderer.domElement );
 
 // animation
 
-function animate( time ) {
+function animate( time: number ) {
 
 	mesh.rotation.x = time / 2000;
 	mesh.rotation.y = time / 1000;


### PR DESCRIPTION
* Create reusable `docker/` directory structure
* Add flexible `build.sh` script with optparse support
* Create Dockerfile with multi-stage build
* Add `docker-build` npm script to webgl-test
* Update README with Docker instructions
