### PR TITLE
Implement aggregate addresses

### DIFF
--- a/osc-listener/package.json
+++ b/osc-listener/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "server": "tsx src/server.ts",
     "integration-tests": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.cjs",
-    "unit-tests": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.cjs tests/transformer.test.ts",
+    "unit-tests": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.config.cjs tests/transformer.test.ts tests/aggregate-transformer.test.ts",
     "test": "npm run unit-tests",
     "manual-test": "tests/manual-test.sh"
   },

--- a/osc-listener/src/config.ts
+++ b/osc-listener/src/config.ts
@@ -1,3 +1,5 @@
+import { AggregateConfig } from './types/osc';
+
 export enum DebugLevel {
     None = 0,
     Low = 1,
@@ -11,8 +13,9 @@ export interface Config {
     updateRate: number; // in Hz
     serverPort: number;
     debug: DebugLevel;
-    recordData: boolean; // Whether to record raw OSC data to a file
-    recordFileName: string; // The filename to record data to
+    recordData?: boolean; // Whether to record raw OSC data to a file
+    recordFileName?: string;// The filename to record data to
+    aggregateEndpoints?: AggregateConfig[];
 }
 
 export const defaultConfig: Config = {

--- a/osc-listener/src/config.ts
+++ b/osc-listener/src/config.ts
@@ -1,4 +1,4 @@
-import { AggregateConfig } from './types/osc';
+import { AggregateConfig } from './types/osc-listener';
 
 export enum DebugLevel {
     None = 0,
@@ -13,8 +13,8 @@ export interface Config {
     updateRate: number; // in Hz
     serverPort: number;
     debug: DebugLevel;
-    recordData?: boolean; // Whether to record raw OSC data to a file
-    recordFileName?: string;// The filename to record data to
+    recordData: boolean; // Whether to record raw OSC data to a file
+    recordFileName: string;// The filename to record data to
     aggregateEndpoints?: AggregateConfig[];
 }
 

--- a/osc-listener/src/osc-listener.ts
+++ b/osc-listener/src/osc-listener.ts
@@ -1,4 +1,4 @@
-import * as osc from 'osc';
+import osc from 'osc';
 import { Config, DebugLevel } from './config';
 import { OSCMessage, MessageTransformer } from './types/osc-listener';
 import * as fs from 'fs';

--- a/osc-listener/src/osc-listener.ts
+++ b/osc-listener/src/osc-listener.ts
@@ -1,7 +1,6 @@
 import osc from 'osc';
 import { Config, DebugLevel } from './config';
-import { OSCMessage } from './types/osc';
-import { MessageTransformer } from './transformer/transformer';
+import { OSCMessage, MessageTransformer } from './types/osc-listener';
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/osc-listener/src/osc-listener.ts
+++ b/osc-listener/src/osc-listener.ts
@@ -1,4 +1,4 @@
-import osc from 'osc';
+import * as osc from 'osc';
 import { Config, DebugLevel } from './config';
 import { OSCMessage, MessageTransformer } from './types/osc-listener';
 import * as fs from 'fs';

--- a/osc-listener/src/server.ts
+++ b/osc-listener/src/server.ts
@@ -4,7 +4,7 @@ import { Config, defaultConfig, DebugLevel } from './config';
 import { OSCListener } from './osc-listener';
 import { TransformerFactory, aggregateFunctions } from './transformer/transformer-factory';
 import { AggregateTransformer } from './transformer/aggregate-transformer';
-import { MessageTransformer, AggregateConfig } from './types/osc';
+import { MessageTransformer, AggregateConfig } from './types/osc-listener';
 import { v4 as uuidv4 } from 'uuid';
 
 const app = express();

--- a/osc-listener/src/transformer/aggregate-transformer.ts
+++ b/osc-listener/src/transformer/aggregate-transformer.ts
@@ -1,0 +1,131 @@
+import { AggregateConfig, AggregateFunction, MessageTransformer, OSCMessage } from '../types/osc';
+import { SimpleTransformer } from './transformer';
+
+export class AggregateTransformer implements MessageTransformer {
+    private baseTransformer: MessageTransformer;
+    private virtualAddresses: Map<string, AggregateConfig>;
+
+    constructor(baseTransformer: MessageTransformer, aggregateConfigs: AggregateConfig[] = []) {
+        this.baseTransformer = baseTransformer;
+        this.virtualAddresses = new Map();
+        
+        // Register all aggregate configs
+        for (const config of aggregateConfigs) {
+            this.registerVirtualAddress(config);
+        }
+    }
+
+    /**
+     * Register a new virtual address with its source addresses and aggregation function
+     */
+    registerVirtualAddress(config: AggregateConfig): void {
+        this.virtualAddresses.set(config.virtualAddress, config);
+    }
+
+    /**
+     * Pass incoming messages to the base transformer
+     */
+    addMessage(message: OSCMessage): void {
+        this.baseTransformer.addMessage(message);
+    }
+
+    /**
+     * Get all available addresses (real + virtual)
+     */
+    getAddresses(): string[] {
+        const baseAddresses = this.baseTransformer.getAddresses();
+        const virtualAddresses = Array.from(this.virtualAddresses.keys());
+        return [...baseAddresses, ...virtualAddresses];
+    }
+
+    /**
+     * Get all real addresses (excluding virtual ones)
+     */
+    getRealAddresses(): string[] {
+        return this.baseTransformer.getAddresses();
+    }
+
+    /**
+     * Get all virtual addresses
+     */
+    getVirtualAddresses(): string[] {
+        return Array.from(this.virtualAddresses.keys());
+    }
+
+    /**
+     * Get transformed messages for all addresses (real + virtual)
+     */
+    getTransformedMessages(): Map<string, number[]> {
+        const result = new Map<string, number[]>();
+        
+        // Get base transformer results
+        const baseResults = this.baseTransformer.getTransformedMessages();
+        for (const [address, value] of baseResults.entries()) {
+            result.set(address, value);
+        }
+        
+        // Add virtual addresses
+        for (const virtualAddress of this.virtualAddresses.keys()) {
+            const value = this.getTransformedAddress(virtualAddress);
+            if (value !== null) {
+                result.set(virtualAddress, value);
+            }
+        }
+        
+        return result;
+    }
+
+    /**
+     * Get transformed value for a specific address (real or virtual)
+     */
+    getTransformedAddress(address: string): number[] | null {
+        // Check if this is a virtual address
+        if (this.virtualAddresses.has(address)) {
+            return this.getTransformedVirtualAddress(address);
+        }
+        
+        // Otherwise, delegate to base transformer
+        return this.baseTransformer.getTransformedAddress(address);
+    }
+
+    /**
+     * Get buffer contents for a real address
+     */
+    getBufferContents(address: string): number[][] {
+        // Virtual addresses don't have buffer contents
+        if (this.virtualAddresses.has(address)) {
+            return [];
+        }
+        
+        // For SimpleTransformer, use its getBufferContents method
+        if (this.baseTransformer instanceof SimpleTransformer) {
+            return this.baseTransformer.getBufferContents(address);
+        }
+        
+        // Default fallback
+        return [];
+    }
+
+    /**
+     * Get the transformed value for a virtual address by applying its aggregate function
+     */
+    private getTransformedVirtualAddress(virtualAddress: string): number[] | null {
+        const config = this.virtualAddresses.get(virtualAddress);
+        if (!config) return null;
+        
+        // Collect values from all source addresses
+        const sourceValues = new Map<string, number[]>();
+        for (const sourceAddress of config.sourceAddresses) {
+            const value = this.baseTransformer.getTransformedAddress(sourceAddress);
+            if (value !== null) {
+                sourceValues.set(sourceAddress, value);
+            }
+        }
+        
+        // If we have no source values, return null
+        if (sourceValues.size === 0) return null;
+        
+        // Apply the aggregate function to the collected values
+        return config.aggregateFunction(sourceValues);
+    }
+} 

--- a/osc-listener/src/transformer/aggregate-transformer.ts
+++ b/osc-listener/src/transformer/aggregate-transformer.ts
@@ -1,4 +1,4 @@
-import { AggregateConfig, AggregateFunction, MessageTransformer, OSCMessage } from '../types/osc';
+import { AggregateConfig, AggregateFunction, MessageTransformer, OSCMessage } from '../types/osc-listener';
 import { SimpleTransformer } from './transformer';
 
 export class AggregateTransformer implements MessageTransformer {

--- a/osc-listener/src/transformer/transformer-factory.ts
+++ b/osc-listener/src/transformer/transformer-factory.ts
@@ -1,4 +1,4 @@
-import { AggregateConfig, AggregateFunction } from '../types/osc';
+import { AggregateConfig, AggregateFunction } from '../types/osc-listener';
 import { AggregateTransformer } from './aggregate-transformer';
 import { SimpleTransformer } from './transformer';
 

--- a/osc-listener/src/transformer/transformer.ts
+++ b/osc-listener/src/transformer/transformer.ts
@@ -1,12 +1,4 @@
-import { OSCMessage, TransformFunction, ElementTransformFunction, AddressBuffer } from '../types/osc';
-
-export interface MessageTransformer {
-    addMessage(message: OSCMessage): void;
-    getAddresses(): string[];
-    getTransformedMessages(): Map<string, number[]>;
-    getTransformedAddress(address: string): number[] | null;
-    getBufferContents(address: string): number[][];
-}
+import { OSCMessage, TransformFunction, ElementTransformFunction, AddressBuffer, MessageTransformer } from '../types/osc';
 
 export class SimpleTransformer implements MessageTransformer {
     private buffers: Map<string, AddressBuffer>;

--- a/osc-listener/src/transformer/transformer.ts
+++ b/osc-listener/src/transformer/transformer.ts
@@ -1,4 +1,4 @@
-import { OSCMessage, TransformFunction, ElementTransformFunction, AddressBuffer, MessageTransformer } from '../types/osc';
+import { OSCMessage, TransformFunction, ElementTransformFunction, AddressBuffer, MessageTransformer } from '../types/osc-listener';
 
 export class SimpleTransformer implements MessageTransformer {
     private buffers: Map<string, AddressBuffer>;

--- a/osc-listener/src/types/osc-listener.d.ts
+++ b/osc-listener/src/types/osc-listener.d.ts
@@ -1,0 +1,34 @@
+import { Message } from 'osc';
+
+// Our OSC Message with timestamp
+export interface OSCMessage {
+    address: string;
+    args: number[];
+    timestamp: number;
+}
+
+// Transformer types
+export type TransformFunction = (values: number[][]) => number[];
+export type ElementTransformFunction = (value: number[], address: string) => number[];
+export type AddressBuffer = { 
+    values: number[][];  // Array of message args arrays
+    timestamps: number[] 
+};
+
+// Aggregate types
+export type AggregateFunction = (sourceValues: Map<string, number[]>) => number[];
+
+export interface AggregateConfig {
+    virtualAddress: string;
+    sourceAddresses: string[];
+    aggregateFunction: AggregateFunction;
+}
+
+// Transformer interface
+export interface MessageTransformer {
+    addMessage(message: OSCMessage): void;
+    getAddresses(): string[];
+    getTransformedMessages(): Map<string, number[]>;
+    getTransformedAddress(address: string): number[] | null;
+    getBufferContents(address: string): number[][];
+} 

--- a/osc-listener/src/types/osc-module.d.ts
+++ b/osc-listener/src/types/osc-module.d.ts
@@ -1,1 +1,0 @@
-declare module 'osc'; 

--- a/osc-listener/src/types/osc.d.ts
+++ b/osc-listener/src/types/osc.d.ts
@@ -1,35 +1,3 @@
-import { Message as OSCMessage } from 'osc';
-
-// Extend the OSC Message type with our timestamp
-export interface OSCMessage {
-    address: string;
-    args: number[];
-    timestamp: number;
-}
-
-export type TransformFunction = (values: number[][]) => number[];
-export type ElementTransformFunction = (value: number[], address: string) => number[];
-export type AddressBuffer = { 
-    values: number[][];  // Array of message args arrays
-    timestamps: number[] 
-};
-
-export type AggregateFunction = (sourceValues: Map<string, number[]>) => number[];
-
-export interface AggregateConfig {
-    virtualAddress: string;
-    sourceAddresses: string[];
-    aggregateFunction: AggregateFunction;
-}
-
-export interface MessageTransformer {
-    addMessage(message: OSCMessage): void;
-    getAddresses(): string[];
-    getTransformedMessages(): Map<string, number[]>;
-    getTransformedAddress(address: string): number[] | null;
-    getBufferContents(address: string): number[][];
-}
-
 // Declare the OSC module
 declare module 'osc' {
     export interface Message {
@@ -69,14 +37,5 @@ declare module 'ws' {
     }
 }
 
-// Our own type that matches the OSC module's UDPPort
-export interface UDPPort {
-    constructor(options: { localAddress: string; localPort: number }): void;
-    on(event: 'ready' | 'error' | 'message', callback: (data: any) => void): void;
-    send(message: any, address: string, port: number): void;
-    open(): void;
-    close(): void;
-}
-
 // Re-export the types we need from the osc module
-export { UDPPort, Message, UDPPortOptions } from 'osc'; 
+export { Message, UDPPortOptions, UDPPort } from 'osc'; 

--- a/osc-listener/src/types/osc.d.ts
+++ b/osc-listener/src/types/osc.d.ts
@@ -14,11 +14,20 @@ export type AddressBuffer = {
     timestamps: number[] 
 };
 
+export type AggregateFunction = (sourceValues: Map<string, number[]>) => number[];
+
+export interface AggregateConfig {
+    virtualAddress: string;
+    sourceAddresses: string[];
+    aggregateFunction: AggregateFunction;
+}
+
 export interface MessageTransformer {
     addMessage(message: OSCMessage): void;
     getAddresses(): string[];
-    getTransformedMessages(): Map<string, number>;
-    getTransformedAddress(address: string): number | null;
+    getTransformedMessages(): Map<string, number[]>;
+    getTransformedAddress(address: string): number[] | null;
+    getBufferContents(address: string): number[][];
 }
 
 // Declare the OSC module
@@ -70,25 +79,4 @@ export interface UDPPort {
 }
 
 // Re-export the types we need from the osc module
-export { UDPPort, Message, UDPPortOptions } from 'osc';
-
-// Our extended types
-export interface OSCMessage {
-    address: string;
-    args: number[];
-    timestamp: number;
-}
-
-export type TransformFunction = (values: number[][]) => number[];
-export type ElementTransformFunction = (value: number[], address: string) => number[];
-export type AddressBuffer = { 
-    values: number[][];  // Array of message args arrays
-    timestamps: number[] 
-};
-
-export interface MessageTransformer {
-    addMessage(message: OSCMessage): void;
-    getAddresses(): string[];
-    getTransformedMessages(): Map<string, number>;
-    getTransformedAddress(address: string): number | null;
-} 
+export { UDPPort, Message, UDPPortOptions } from 'osc'; 

--- a/osc-listener/src/types/osc.d.ts
+++ b/osc-listener/src/types/osc.d.ts
@@ -1,25 +1,21 @@
-// Declare the OSC module
-declare module 'osc' {
-    export interface Message {
-        address: string;
-        args: Array<{
-            type: string;
-            value: number;
-        }>;
-    }
-
-    export interface UDPPortOptions {
+// OSC module declaration
+declare namespace osc {
+    interface UDPPortOptions {
         localAddress: string;
         localPort: number;
     }
 
-    export class UDPPort {
+    class UDPPort {
         constructor(options: UDPPortOptions);
-        on(event: 'ready' | 'error' | 'message', callback: (data: any) => void): void;
-        send(message: Message, address: string, port: number): void;
+        on(event: string, callback: (data: any) => void): void;
         open(): void;
         close(): void;
+        send(message: any, address: string, port: number): void;
     }
+}
+
+declare module 'osc' {
+    export = osc;
 }
 
 declare module 'ws' {
@@ -35,7 +31,4 @@ declare module 'ws' {
         on(event: 'connection', callback: (ws: WebSocket) => void): void;
         close(): void;
     }
-}
-
-// Re-export the types we need from the osc module
-export { Message, UDPPortOptions, UDPPort } from 'osc'; 
+} 

--- a/osc-listener/tests/aggregate-transformer.test.ts
+++ b/osc-listener/tests/aggregate-transformer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { AggregateTransformer } from '../src/transformer/aggregate-transformer';
 import { SimpleTransformer } from '../src/transformer/transformer';
-import { OSCMessage } from '../src/types/osc';
+import { OSCMessage } from '../src/types/osc-listener';
 import { aggregateFunctions } from '../src/transformer/transformer-factory';
 
 describe('AggregateTransformer', () => {

--- a/osc-listener/tests/aggregate-transformer.test.ts
+++ b/osc-listener/tests/aggregate-transformer.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from '@jest/globals';
+import { AggregateTransformer } from '../src/transformer/aggregate-transformer';
+import { SimpleTransformer } from '../src/transformer/transformer';
+import { OSCMessage } from '../src/types/osc';
+import { aggregateFunctions } from '../src/transformer/transformer-factory';
+
+describe('AggregateTransformer', () => {
+    // Simple identity transform function for testing
+    const identityTransform = (values: number[][]) => {
+        return values.length > 0 ? values[values.length - 1] : [];
+    };
+
+    it('should delegate to base transformer for real addresses', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer);
+        
+        // Add message to base transformer
+        baseTransformer.addMessage({
+            address: '/test',
+            args: [1, 2, 3],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Should be accessible through aggregate transformer
+        const value = aggregateTransformer.getTransformedAddress('/test');
+        expect(value).toEqual([1, 2, 3]);
+    });
+
+    it('should compute virtual address values using average function', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/average',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.average
+            }
+        ]);
+        
+        // Add messages to source addresses
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 20, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [20, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check virtual address value
+        const value = aggregateTransformer.getTransformedAddress('/virtual/average');
+        expect(value).toEqual([15, 30, 45]); // Average of [10, 20, 30] and [20, 40, 60]
+    });
+
+    it('should compute virtual address values using sum function', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/sum',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.sum
+            }
+        ]);
+        
+        // Add messages to source addresses
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 20, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [20, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check virtual address value
+        const value = aggregateTransformer.getTransformedAddress('/virtual/sum');
+        expect(value).toEqual([30, 60, 90]); // Sum of [10, 20, 30] and [20, 40, 60]
+    });
+
+    it('should compute virtual address values using max function', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/max',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.max
+            }
+        ]);
+        
+        // Add messages to source addresses
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 50, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [20, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check virtual address value
+        const value = aggregateTransformer.getTransformedAddress('/virtual/max');
+        expect(value).toEqual([20, 50, 60]); // Max of [10, 50, 30] and [20, 40, 60]
+    });
+
+    it('should compute virtual address values using min function', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/min',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.min
+            }
+        ]);
+        
+        // Add messages to source addresses
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 50, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [20, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check virtual address value
+        const value = aggregateTransformer.getTransformedAddress('/virtual/min');
+        expect(value).toEqual([10, 40, 30]); // Min of [10, 50, 30] and [20, 40, 60]
+    });
+
+    it('should compute virtual address values using nonZeroAverage function', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/nonZeroAverage',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.nonZeroAverage
+            }
+        ]);
+        
+        // Add messages to source addresses with zero values mixed in
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 0, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [0, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check virtual address value - should average only non-zero values
+        const value = aggregateTransformer.getTransformedAddress('/virtual/nonZeroAverage');
+        
+        // Expected: [10/1, 40/1, (30+60)/2] = [10, 40, 45]
+        // First value: only '/source1' has non-zero (10)
+        // Second value: only '/source2' has non-zero (40)
+        // Third value: both have non-zero (30, 60), average is 45
+        expect(value).toEqual([10, 40, 45]);
+    });
+
+    it('should return all addresses including virtual ones', () => {
+        const baseTransformer = new SimpleTransformer(identityTransform);
+        const aggregateTransformer = new AggregateTransformer(baseTransformer, [
+            {
+                virtualAddress: '/virtual/average',
+                sourceAddresses: ['/source1', '/source2'],
+                aggregateFunction: aggregateFunctions.average
+            }
+        ]);
+        
+        // Add messages to source addresses
+        baseTransformer.addMessage({
+            address: '/source1',
+            args: [10, 20, 30],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        baseTransformer.addMessage({
+            address: '/source2',
+            args: [20, 40, 60],
+            timestamp: 1000
+        } as OSCMessage);
+        
+        // Check addresses
+        const addresses = aggregateTransformer.getAddresses();
+        expect(addresses).toContain('/source1');
+        expect(addresses).toContain('/source2');
+        expect(addresses).toContain('/virtual/average');
+        expect(addresses.length).toBe(3);
+        
+        // Check virtual addresses
+        const virtualAddresses = aggregateTransformer.getVirtualAddresses();
+        expect(virtualAddresses).toContain('/virtual/average');
+        expect(virtualAddresses.length).toBe(1);
+        
+        // Check real addresses
+        const realAddresses = aggregateTransformer.getRealAddresses();
+        expect(realAddresses).toContain('/source1');
+        expect(realAddresses).toContain('/source2');
+        expect(realAddresses.length).toBe(2);
+    });
+}); 

--- a/osc-listener/tests/transformer.test.ts
+++ b/osc-listener/tests/transformer.test.ts
@@ -1,5 +1,5 @@
 import { SimpleTransformer } from '../src/transformer/transformer';
-import { OSCMessage } from '../src/types/osc';
+import { OSCMessage } from '../src/types/osc-listener';
 import { describe, it, expect } from '@jest/globals';
 
 describe('SimpleTransformer', () => {

--- a/osc-listener/tsconfig.json
+++ b/osc-listener/tsconfig.json
@@ -13,7 +13,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts", "frontend/**/*.ts"]
 } 

--- a/osc-wave-visualizer/src/osc-data-fetcher.ts
+++ b/osc-wave-visualizer/src/osc-data-fetcher.ts
@@ -13,11 +13,11 @@ export class OSCDataFetcher {
     constructor(port: number = 3001) {
         this.baseUrl = `http://localhost:${port}/api/messages/`;
         this.waveAddresses = new Map([
-            ['alpha', '/muse/elements/alpha_absolute2'],
-            ['beta', '/muse/elements/beta_absolute2'],
-            ['delta', '/muse/elements/delta_absolute2'],
-            ['gamma', '/muse/elements/gamma_absolute2'],
-            ['theta', '/muse/elements/theta_absolute2']
+            ['alpha', '/muse/alpha_average'],
+            ['beta', '/muse/beta_average'],
+            ['delta', '/muse/delta_average'],
+            ['gamma', '/muse/gamma_average'],
+            ['theta', '/muse/theta_average']
         ]);
     }
 
@@ -37,7 +37,7 @@ export class OSCDataFetcher {
                 if (!response.ok) {
                     console.error(`Failed to fetch ${wave} data:`, response.statusText);
                     
-                    const fallbackAddress = `/muse/elements/${wave}_average`;
+                    const fallbackAddress = `/muse/elements/${wave}_absolute2`;
                     console.log(`Trying fallback address: ${fallbackAddress}`);
                     
                     const fallbackResponse = await fetch(`${this.baseUrl}${fallbackAddress}`);
@@ -60,4 +60,4 @@ export class OSCDataFetcher {
 
         return waveData;
     }
-} 
+}


### PR DESCRIPTION
### Features

* Add aggregate endpoints and improve type definitions
    * Added virtual aggregate endpoints that combine data from multiple OSC addresses
    * Added nonZeroAverage function to aggregate only non-zero values
* Default Brain Wave Aggregates Implementation
    * Implemented default brain wave aggregates in transformer factory
    * Added automatic fallback to default aggregates when none provided

### Bugfixes

* Improve session management to use HTTP headers
    * Return session ID from the /api/start endpoint
    * Clients are responsible to provide the returned token in X-Session-ID header
* Rely on esModuleInterop to properly import osc

### Refactors

* OSC Module Type Declarations
    * Remove extra type declaration file
    * Fixed type declarations for the OSC module to correctly match implementation
    * Resolved TypeScript validation issues with OSC module imports
* Reorganize type definitions for better separation of concerns
    * Created dedicated osc-listener.d.ts for internal type definitions
    * Cleaned up osc.d.ts to only contain external module declarations
    * Fixed potential issues with null/undefined values
* Enhance AggregateTransformer Buffer Management and Visualizer Integration
    * Update visualizer to use average endpoints for brain wave data
    * Implement buffer management for virtual addresses in AggregateTransformer
    * Improve handling of missing source data
